### PR TITLE
Update request-promise dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/securionpay/securionpay-node#readme",
   "dependencies": {
     "lodash": "^4.0.0",
-    "request-promise": "^2.0.0"
+    "request-promise": "^4.2.6"
   },
   "devDependencies": {
     "bluebird": "^3.1.2",


### PR DESCRIPTION
Found Moderate issue in the  `request-promise` dependency's dependencies:  request-promise` json-schema`. Since it is a bit outdated, they won't downgrade the fix for versions `^2.0.0`. 

Attached `npm audit` report:


```
│ Moderate      │ json-schema is vulnerable to Prototype Pollution             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ json-schema                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=0.4.0                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ securionpay                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ securionpay > request-promise > request > http-signature >   │
│               │ jsprim > json-schema                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://github.com/advisories/GHSA-896r-f27r-55mw
```